### PR TITLE
Check regex result when matching base64 svgs to avoid null exception.

### DIFF
--- a/components/Icon/Icon.tsx
+++ b/components/Icon/Icon.tsx
@@ -30,7 +30,7 @@ export default class Icon extends React.Component<Props, {}> {
     let src = this.props.src
 
     const match = src.match(/data:image\/svg[^,]*?(;base64)?,(.*)/)
-    if (match[1] && match[2]) {
+    if (match && match[1] && match[2]) {
       src = atob(match[2])
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphcool-styles",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Shared style resources between Graphcool projects",
   "main": "dist/build.js",
   "files": [


### PR DESCRIPTION
Simple bug fix as per title. This is causing problems in other dependent projects (like graphcool-graphiql) so if someone can please take a look when they're free it will be much appreciated! 

Thanks.