### PR TITLE
Change react peerDependency from ^0.15.0 to ^15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "webpack": "^2.1.0-beta.25"
   },
   "peerDependencies": {
-    "react": "^0.15.0"
+    "react": "^15.0.0"
   },
   "dependencies": {
     "html-webpack-plugin": "^2.24.1",


### PR DESCRIPTION
Version 0.15.x is no longer published and has been replaced with 15.x.x